### PR TITLE
Make sure tree already exists before linting

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -26,8 +26,11 @@ module.exports = class Linter {
     if (!this.editor.alive || !this.filePath) { return; } // AFAIK the linter package itself only works with an existing path
 
     this.lintMessages = [];
-    this.lintErrors(this.editor.languageMode.tree.rootNode);
-    this.linterInterface.setMessages(this.filePath, this.lintMessages);
+    const tree = this.editor.languageMode.tree;
+    if (tree) {
+        this.lintErrors(tree.rootNode);
+        this.linterInterface.setMessages(this.filePath, this.lintMessages);
+    }
   }
 
   lintErrors(node) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-tree-sitter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Display errors in the file parse using the linter API",
   "main": "lib/main.js",
   "repository": "https://github.com/Aerijo/linter-tree-sitter",


### PR DESCRIPTION
First of all: Thanks for your work on this! I'd have to write this myself if you hadn't, and I'm very happy you were the first.

When opening Atom with a linted file already open or when reloading the window with Ctrl+Shift+F5, I often get the error below – presumably because linter-tree-sitter tries to lint before tree-sitter finished building the tree. This pull request fixes this.

Ideally, the linter should be triggered once tree-sitter has done its work because with this pull request, the linting errors are only displayed after some edits when `onDidStopChanging` fires. Not sure if that's possible.

### Stack Trace

Failed to activate the linter-tree-sitter package

```
At Cannot read property 'rootNode' of null

TypeError: Cannot read property 'rootNode' of null
    at Linter.lint (/packages/linter-tree-sitter/lib/linter.js:29:51)
    at /packages/linter-tree-sitter/lib/linter.js:16:10)
    at EditorRegistry.addSubscription (/packages/linter-tree-sitter/lib/editor-registry.js:56:24)
    at lifeCycleDisposables.add.editor.observeGrammar.grammar (/packages/linter-tree-sitter/lib/editor-registry.js:36:16)
    at TextEditor.observeGrammar (/usr/share/atom/resources/app/src/text-editor.js:753:11)
    at EditorRegistry.add (/packages/linter-tree-sitter/lib/editor-registry.js:29:14)
    at disposables.add.atom.workspace.observeTextEditors.editor (/packages/linter-tree-sitter/lib/main.js:26:25)
    at Workspace.observeTextEditors (/usr/share/atom/resources/app/src/workspace.js:647:59)
    at Object.consumeIndie (/packages/linter-tree-sitter/lib/main.js:25:22)
    at Provider.module.exports.Provider.provide (/usr/share/atom/resources/app/node_modules/service-hub/lib/provider.js:34:58)
    at ServiceHub.module.exports.ServiceHub.consume (/usr/share/atom/resources/app/node_modules/service-hub/lib/service-hub.js:50:24)
    at Package.activateServices (/usr/share/atom/resources/app/src/package.js:405:79)
    at Package.activateNow (/usr/share/atom/resources/app/src/package.js:233:20)
    at measure (/usr/share/atom/resources/app/src/package.js:206:33)
    at Package.measure (/usr/share/atom/resources/app/src/package.js:88:25)
    at activationPromise.Promise (/usr/share/atom/resources/app/src/package.js:200:20)
    at new Promise (<anonymous>)
    at Package.activate (/usr/share/atom/resources/app/src/package.js:198:38)
    at PackageManager.activatePackage (/usr/share/atom/resources/app/src/package-manager.js:696:42)
    at config.transactAsync (/usr/share/atom/resources/app/src/package-manager.js:671:36)
    at Config.transactAsync (/usr/share/atom/resources/app/src/config.js:852:28)
    at PackageManager.activatePackages (/usr/share/atom/resources/app/src/package-manager.js:669:23)
    at PackageManager.activate (/usr/share/atom/resources/app/src/package-manager.js:648:50)
    at loadStatePromise.loadState.then (/usr/share/atom/resources/app/src/atom-environment.js:875:27)
    at <anonymous>
```