### PR TITLE
Support linting of injected grammars

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -29,8 +29,17 @@ module.exports = class Linter {
     const tree = this.editor.languageMode.tree;
     if (tree) {
         this.lintErrors(tree.rootNode);
-        this.linterInterface.setMessages(this.filePath, this.lintMessages);
     }
+
+    const injectionMarkers = this.editor.languageMode.injectionsMarkerLayer.findMarkers({});
+    for (const injectionMarker of injectionMarkers) {
+      const tree = injectionMarker.languageLayer.tree;
+      if (tree) {
+        this.lintErrors(tree.rootNode);
+      }
+    }
+
+    this.linterInterface.setMessages(this.filePath, this.lintMessages);
   }
 
   lintErrors(node) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linter-tree-sitter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Display errors in the file parse using the linter API",
   "main": "lib/main.js",
   "repository": "https://github.com/Aerijo/linter-tree-sitter",


### PR DESCRIPTION
Method to access the injected tree copied from Atom's [src/tree-sitter-language-mode.js](https://github.com/atom/atom/blob/0b6876c4c6b57be8dc355b327be54082480230ef/src/tree-sitter-language-mode.js#L294).