### PR TITLE
Make sure initial lint is successful

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -13,7 +13,13 @@ module.exports = class Linter {
 
     );
 
-    this.lint(); // kick off the first lint
+    this.initialLint(this, 10);
+  }
+
+  initialLint(self, remainingAttempts) {
+    if (!self.lint() && remainingAttempts > 0) {
+      setTimeout(self.initialLint, 1000, self, remainingAttempts - 1);
+    }
   }
 
   remove() {
@@ -27,9 +33,10 @@ module.exports = class Linter {
 
     this.lintMessages = [];
     const tree = this.editor.languageMode.tree;
-    if (tree) {
-        this.lintErrors(tree.rootNode);
+    if (!tree) {
+      return false;
     }
+    this.lintErrors(tree.rootNode);
 
     const injectionMarkers = this.editor.languageMode.injectionsMarkerLayer.findMarkers({});
     for (const injectionMarker of injectionMarkers) {
@@ -40,6 +47,7 @@ module.exports = class Linter {
     }
 
     this.linterInterface.setMessages(this.filePath, this.lintMessages);
+    return true;
   }
 
   lintErrors(node) {


### PR DESCRIPTION
When Atom is not running yet and it is opened with a file from the command line, or when Atom is reloaded with Ctrl+Shift+F5, the initial lint fails for me. This PR introduces multiple linting attempts for the initial lint.