### PR TITLE
Only attempt to clear messages with a path

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -23,7 +23,9 @@ module.exports = class Linter {
   }
 
   remove() {
-    this.linterInterface.setMessages(this.filePath, []);
+    if (this.filePath) {
+      this.linterInterface.setMessages(this.filePath, []);
+    }
     this.textDisposables.dispose();
   }
 


### PR DESCRIPTION
If changing the language on an unsaved buffer previously an error would be thrown from `linter` as this provider was attempting to set the messages for `undefined` to `[]`.
